### PR TITLE
Enhance model training and API integration

### DIFF
--- a/demo-cdk/bin/cloudai-demo-cdk.ts
+++ b/demo-cdk/bin/cloudai-demo-cdk.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 import * as cdk from 'aws-cdk-lib';
 import { CloudaiDemoCdkStack } from '../lib/cloudai-demo-cdk-stack';
+import { ArchTrainingStack } from '../lib/arch-training-stack';
 
 const app = new cdk.App();
 new CloudaiDemoCdkStack(app, 'CloudaiDemoCdkStack'); 
+new ArchTrainingStack(app, 'CloudaiArchTrainingStack'); 

--- a/demo-cdk/dist/bin/cloudai-demo-cdk.js
+++ b/demo-cdk/dist/bin/cloudai-demo-cdk.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+const cdk = __importStar(require("aws-cdk-lib"));
+const cloudai_demo_cdk_stack_1 = require("../lib/cloudai-demo-cdk-stack");
+const arch_training_stack_1 = require("../lib/arch-training-stack");
+const app = new cdk.App();
+new cloudai_demo_cdk_stack_1.CloudaiDemoCdkStack(app, 'CloudaiDemoCdkStack');
+new arch_training_stack_1.ArchTrainingStack(app, 'CloudaiArchTrainingStack');

--- a/demo-cdk/dist/lib/arch-training-stack.js
+++ b/demo-cdk/dist/lib/arch-training-stack.js
@@ -1,0 +1,223 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.ArchTrainingStack = void 0;
+const cdk = __importStar(require("aws-cdk-lib"));
+const lambda = __importStar(require("aws-cdk-lib/aws-lambda"));
+const s3 = __importStar(require("aws-cdk-lib/aws-s3"));
+const iam = __importStar(require("aws-cdk-lib/aws-iam"));
+const sfn = __importStar(require("aws-cdk-lib/aws-stepfunctions"));
+const tasks = __importStar(require("aws-cdk-lib/aws-stepfunctions-tasks"));
+const events = __importStar(require("aws-cdk-lib/aws-events"));
+const targets = __importStar(require("aws-cdk-lib/aws-events-targets"));
+const ec2 = __importStar(require("aws-cdk-lib/aws-ec2"));
+/**
+ * ArchTrainingStack sets up:
+ * 1. S3 bucket to store raw metadata & training artefacts
+ * 2. Lambda to collect AWS architecture metadata → S3 (raw/)
+ * 3. Lambda to convert raw JSON → JSONL friendly for fine-tuning (train/)
+ * 4. Step-Functions State Machine that orchestrates:
+ *      Collect → Prep → SageMaker TrainingJob
+ * 5. EventBridge rule that triggers the State Machine on a cron schedule
+ */
+class ArchTrainingStack extends cdk.Stack {
+    constructor(scope, id, props = {}) {
+        super(scope, id, props);
+        const bucket = new s3.Bucket(this, 'ArchTrainingBucket', {
+            encryption: s3.BucketEncryption.S3_MANAGED,
+            lifecycleRules: [
+                { expiration: cdk.Duration.days(30) }, // keep artefacts 30 days
+            ],
+        });
+        //---------------------------------------------------------------------
+        // 1. Data-collection Lambda
+        //---------------------------------------------------------------------
+        const collectorRole = new iam.Role(this, 'CollectorRole', {
+            assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
+        });
+        // Basic execution & read-only permissions
+        collectorRole.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaBasicExecutionRole'));
+        collectorRole.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('ReadOnlyAccess'));
+        bucket.grantWrite(collectorRole);
+        const dataCollector = new lambda.Function(this, 'DataCollectorFn', {
+            runtime: lambda.Runtime.PYTHON_3_11,
+            handler: 'index.handler',
+            code: lambda.Code.fromInline(`import boto3, json, os, datetime, tempfile, gzip
+import urllib.parse
+
+def handler(event, context):
+    """Collect high-level AWS resource metadata and upload to S3 as gzipped JSON."""
+    session = boto3.Session()
+    resources = []
+
+    # Lambda functions example – extend with more AWS services
+    lambda_client = session.client('lambda')
+    for page in lambda_client.get_paginator('list_functions').paginate():
+        for fn in page.get('Functions', []):
+            resources.append({'Type': 'Lambda', 'FunctionName': fn['FunctionName'], 'Arn': fn['FunctionArn']})
+
+    # TODO: add API Gateway, SNS, SQS, etc.
+
+    # Dump to tmp file then upload
+    ts = datetime.datetime.utcnow().strftime('%Y%m%dT%H%M%SZ')
+    key = f"raw/{ts}.json.gz"
+    tmp = tempfile.NamedTemporaryFile(delete=False)
+    with gzip.open(tmp.name, 'wt', encoding='utf-8') as f:
+        json.dump(resources, f)
+    s3 = session.client('s3')
+    bucket = os.environ['BUCKET_NAME']
+    s3.upload_file(tmp.name, bucket, key)
+    return {'status': 'ok', 'objects': len(resources), 's3_key': key}
+`),
+            role: collectorRole,
+            timeout: cdk.Duration.minutes(5),
+            environment: {
+                BUCKET_NAME: bucket.bucketName,
+            },
+        });
+        //---------------------------------------------------------------------
+        // 2. Data-prep Lambda (JSON → JSONL For fine-tune)
+        //---------------------------------------------------------------------
+        const prepRole = new iam.Role(this, 'PrepRole', {
+            assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
+        });
+        prepRole.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaBasicExecutionRole'));
+        bucket.grantReadWrite(prepRole);
+        const dataPrep = new lambda.Function(this, 'DataPrepFn', {
+            runtime: lambda.Runtime.PYTHON_3_11,
+            handler: 'index.handler',
+            code: lambda.Code.fromInline(`import boto3, json, os, gzip, io, datetime, tempfile
+
+def handler(event, context):
+    """Convert collected JSON to JSONL pairs for training (simple demo)."""
+    s3 = boto3.client('s3')
+    bucket = os.environ['BUCKET_NAME']
+    key = event.get('raw_key')
+    if not key:
+        raise ValueError('raw_key missing')
+
+    obj = s3.get_object(Bucket=bucket, Key=key)
+    raw = json.loads(gzip.decompress(obj['Body'].read()).decode('utf-8'))
+
+    # Very naive Q&A pair generation
+    jsonl_lines = []
+    for r in raw:
+        if r['Type'] == 'Lambda':
+            q = f"What triggers the {r['FunctionName']} Lambda?"
+            a = f"It is triggered by X (placeholder – user needs richer context)."
+            jsonl_lines.append(json.dumps({'prompt': q, 'completion': a}))
+
+    ts = datetime.datetime.utcnow().strftime('%Y%m%dT%H%M%SZ')
+    out_key = f"train/{ts}.jsonl"
+    s3.put_object(Bucket=bucket, Key=out_key, Body='\n'.join(jsonl_lines).encode('utf-8'))
+    return {'status': 'ok', 'train_key': out_key, 'records': len(jsonl_lines)}
+`),
+            role: prepRole,
+            timeout: cdk.Duration.minutes(5),
+            environment: {
+                BUCKET_NAME: bucket.bucketName,
+            },
+        });
+        //---------------------------------------------------------------------
+        // 3. SageMaker training task definition
+        //---------------------------------------------------------------------
+        // IAM role that SageMaker uses inside the training container
+        const sagemakerExecRole = new iam.Role(this, 'SageMakerExecRole', {
+            assumedBy: new iam.ServicePrincipal('sagemaker.amazonaws.com'),
+        });
+        bucket.grantReadWrite(sagemakerExecRole);
+        sagemakerExecRole.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonSageMakerFullAccess'));
+        const trainingJobTask = new tasks.SageMakerCreateTrainingJob(this, 'CreateTrainingJob', {
+            trainingJobName: sfn.JsonPath.stringAt('$$.Execution.Name'),
+            algorithmSpecification: {
+                algorithmName: 'xgboost', // Placeholder built-in algorithm, replace with LLM fine-tune image as needed
+                trainingInputMode: tasks.InputMode.FILE,
+            },
+            inputDataConfig: [
+                {
+                    channelName: 'training',
+                    dataSource: {
+                        s3DataSource: {
+                            s3DataType: tasks.S3DataType.S3_PREFIX,
+                            s3Location: tasks.S3Location.fromBucket(bucket, 'train/'),
+                        },
+                    },
+                    contentType: 'application/jsonlines',
+                },
+            ],
+            outputDataConfig: {
+                s3OutputLocation: tasks.S3Location.fromBucket(bucket, 'model-artifacts'),
+            },
+            resourceConfig: {
+                instanceCount: 1,
+                instanceType: new ec2.InstanceType('ml.m5.large'),
+                volumeSize: cdk.Size.gibibytes(30),
+            },
+            role: sagemakerExecRole,
+            stoppingCondition: {
+                maxRuntime: cdk.Duration.hours(2),
+            },
+            integrationPattern: sfn.IntegrationPattern.RUN_JOB,
+        });
+        //---------------------------------------------------------------------
+        // 4. Assemble Step Functions workflow
+        //---------------------------------------------------------------------
+        const invokeCollector = new tasks.LambdaInvoke(this, 'InvokeCollector', {
+            lambdaFunction: dataCollector,
+            payloadResponseOnly: true,
+            outputPath: '$',
+        });
+        const invokePrep = new tasks.LambdaInvoke(this, 'InvokePrep', {
+            lambdaFunction: dataPrep,
+            payload: sfn.TaskInput.fromObject({ raw_key: sfn.JsonPath.stringAt('$.s3_key') }),
+            payloadResponseOnly: true,
+            outputPath: '$',
+        });
+        const definition = invokeCollector.next(invokePrep).next(trainingJobTask);
+        const stateMachine = new sfn.StateMachine(this, 'ArchTrainingStateMachine', {
+            definition,
+            timeout: cdk.Duration.hours(3),
+        });
+        //---------------------------------------------------------------------
+        // 5. EventBridge schedule
+        //---------------------------------------------------------------------
+        const minutes = props.scheduleMinutes ?? 1440; // default daily
+        new events.Rule(this, 'ArchTrainingSchedule', {
+            schedule: events.Schedule.rate(cdk.Duration.minutes(minutes)),
+            targets: [new targets.SfnStateMachine(stateMachine)],
+        });
+    }
+}
+exports.ArchTrainingStack = ArchTrainingStack;

--- a/demo-cdk/dist/lib/cloudai-demo-cdk-stack.js
+++ b/demo-cdk/dist/lib/cloudai-demo-cdk-stack.js
@@ -1,0 +1,63 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.CloudaiDemoCdkStack = void 0;
+const cdk = __importStar(require("aws-cdk-lib"));
+const lambda = __importStar(require("aws-cdk-lib/aws-lambda"));
+const apigateway = __importStar(require("aws-cdk-lib/aws-apigateway"));
+class CloudaiDemoCdkStack extends cdk.Stack {
+    constructor(scope, id, props) {
+        super(scope, id, props);
+        const demoLambda = new lambda.Function(this, 'DemoLambda', {
+            functionName: 'cloudai-demo-hello',
+            runtime: lambda.Runtime.NODEJS_18_X,
+            handler: 'index.handler',
+            code: lambda.Code.fromInline(`
+        exports.handler = async (event) => {
+          return {
+            statusCode: 200,
+            body: JSON.stringify({ message: "Hello from Lambda!" })
+          };
+        };
+      `),
+        });
+        const api = new apigateway.RestApi(this, 'DemoApi', {
+            restApiName: 'cloudai-demo-api',
+        });
+        const hello = api.root.addResource('hello');
+        hello.addMethod('GET', new apigateway.LambdaIntegration(demoLambda));
+    }
+}
+exports.CloudaiDemoCdkStack = CloudaiDemoCdkStack;

--- a/demo-cdk/lib/arch-training-stack.ts
+++ b/demo-cdk/lib/arch-training-stack.ts
@@ -1,0 +1,206 @@
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as sfn from 'aws-cdk-lib/aws-stepfunctions';
+import * as tasks from 'aws-cdk-lib/aws-stepfunctions-tasks';
+import * as events from 'aws-cdk-lib/aws-events';
+import * as targets from 'aws-cdk-lib/aws-events-targets';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+
+export interface ArchTrainingStackProps extends cdk.StackProps {
+  /** The frequency in minutes to run the background training (default: 1440 – daily) */
+  scheduleMinutes?: number;
+}
+
+/**
+ * ArchTrainingStack sets up:
+ * 1. S3 bucket to store raw metadata & training artefacts
+ * 2. Lambda to collect AWS architecture metadata → S3 (raw/)
+ * 3. Lambda to convert raw JSON → JSONL friendly for fine-tuning (train/)
+ * 4. Step-Functions State Machine that orchestrates:
+ *      Collect → Prep → SageMaker TrainingJob
+ * 5. EventBridge rule that triggers the State Machine on a cron schedule
+ */
+export class ArchTrainingStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props: ArchTrainingStackProps = {}) {
+    super(scope, id, props);
+
+    const bucket = new s3.Bucket(this, 'ArchTrainingBucket', {
+      encryption: s3.BucketEncryption.S3_MANAGED,
+      lifecycleRules: [
+        { expiration: cdk.Duration.days(30) }, // keep artefacts 30 days
+      ],
+    });
+
+    //---------------------------------------------------------------------
+    // 1. Data-collection Lambda
+    //---------------------------------------------------------------------
+    const collectorRole = new iam.Role(this, 'CollectorRole', {
+      assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
+    });
+
+    // Basic execution & read-only permissions
+    collectorRole.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaBasicExecutionRole'));
+    collectorRole.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('ReadOnlyAccess'));
+    bucket.grantWrite(collectorRole);
+
+    const dataCollector = new lambda.Function(this, 'DataCollectorFn', {
+      runtime: lambda.Runtime.PYTHON_3_11,
+      handler: 'index.handler',
+      code: lambda.Code.fromInline(`import boto3, json, os, datetime, tempfile, gzip
+import urllib.parse
+
+def handler(event, context):
+    """Collect high-level AWS resource metadata and upload to S3 as gzipped JSON."""
+    session = boto3.Session()
+    resources = []
+
+    # Lambda functions example – extend with more AWS services
+    lambda_client = session.client('lambda')
+    for page in lambda_client.get_paginator('list_functions').paginate():
+        for fn in page.get('Functions', []):
+            resources.append({'Type': 'Lambda', 'FunctionName': fn['FunctionName'], 'Arn': fn['FunctionArn']})
+
+    # TODO: add API Gateway, SNS, SQS, etc.
+
+    # Dump to tmp file then upload
+    ts = datetime.datetime.utcnow().strftime('%Y%m%dT%H%M%SZ')
+    key = f"raw/{ts}.json.gz"
+    tmp = tempfile.NamedTemporaryFile(delete=False)
+    with gzip.open(tmp.name, 'wt', encoding='utf-8') as f:
+        json.dump(resources, f)
+    s3 = session.client('s3')
+    bucket = os.environ['BUCKET_NAME']
+    s3.upload_file(tmp.name, bucket, key)
+    return {'status': 'ok', 'objects': len(resources), 's3_key': key}
+`),
+      role: collectorRole,
+      timeout: cdk.Duration.minutes(5),
+      environment: {
+        BUCKET_NAME: bucket.bucketName,
+      },
+    });
+
+    //---------------------------------------------------------------------
+    // 2. Data-prep Lambda (JSON → JSONL For fine-tune)
+    //---------------------------------------------------------------------
+    const prepRole = new iam.Role(this, 'PrepRole', {
+      assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
+    });
+    prepRole.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaBasicExecutionRole'));
+    bucket.grantReadWrite(prepRole);
+
+    const dataPrep = new lambda.Function(this, 'DataPrepFn', {
+      runtime: lambda.Runtime.PYTHON_3_11,
+      handler: 'index.handler',
+      code: lambda.Code.fromInline(`import boto3, json, os, gzip, io, datetime, tempfile
+
+def handler(event, context):
+    """Convert collected JSON to JSONL pairs for training (simple demo)."""
+    s3 = boto3.client('s3')
+    bucket = os.environ['BUCKET_NAME']
+    key = event.get('raw_key')
+    if not key:
+        raise ValueError('raw_key missing')
+
+    obj = s3.get_object(Bucket=bucket, Key=key)
+    raw = json.loads(gzip.decompress(obj['Body'].read()).decode('utf-8'))
+
+    # Very naive Q&A pair generation
+    jsonl_lines = []
+    for r in raw:
+        if r['Type'] == 'Lambda':
+            q = f"What triggers the {r['FunctionName']} Lambda?"
+            a = f"It is triggered by X (placeholder – user needs richer context)."
+            jsonl_lines.append(json.dumps({'prompt': q, 'completion': a}))
+
+    ts = datetime.datetime.utcnow().strftime('%Y%m%dT%H%M%SZ')
+    out_key = f"train/{ts}.jsonl"
+    s3.put_object(Bucket=bucket, Key=out_key, Body='\n'.join(jsonl_lines).encode('utf-8'))
+    return {'status': 'ok', 'train_key': out_key, 'records': len(jsonl_lines)}
+`),
+      role: prepRole,
+      timeout: cdk.Duration.minutes(5),
+      environment: {
+        BUCKET_NAME: bucket.bucketName,
+      },
+    });
+
+    //---------------------------------------------------------------------
+    // 3. SageMaker training task definition
+    //---------------------------------------------------------------------
+    // IAM role that SageMaker uses inside the training container
+    const sagemakerExecRole = new iam.Role(this, 'SageMakerExecRole', {
+      assumedBy: new iam.ServicePrincipal('sagemaker.amazonaws.com'),
+    });
+    bucket.grantReadWrite(sagemakerExecRole);
+    sagemakerExecRole.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonSageMakerFullAccess'));
+
+    const trainingJobTask = new tasks.SageMakerCreateTrainingJob(this, 'CreateTrainingJob', {
+      trainingJobName: sfn.JsonPath.stringAt('$$.Execution.Name'),
+      algorithmSpecification: {
+        algorithmName: 'xgboost', // Placeholder built-in algorithm, replace with LLM fine-tune image as needed
+        trainingInputMode: tasks.InputMode.FILE,
+      },
+      inputDataConfig: [
+        {
+          channelName: 'training',
+          dataSource: {
+            s3DataSource: {
+              s3DataType: tasks.S3DataType.S3_PREFIX,
+              s3Location: tasks.S3Location.fromBucket(bucket, 'train/'),
+            },
+          },
+          contentType: 'application/jsonlines',
+        },
+      ],
+      outputDataConfig: {
+        s3OutputLocation: tasks.S3Location.fromBucket(bucket, 'model-artifacts'),
+      },
+      resourceConfig: {
+        instanceCount: 1,
+        instanceType: new ec2.InstanceType('ml.m5.large'),
+        volumeSize: cdk.Size.gibibytes(30),
+      },
+      role: sagemakerExecRole,
+      stoppingCondition: {
+        maxRuntime: cdk.Duration.hours(2),
+      },
+      integrationPattern: sfn.IntegrationPattern.RUN_JOB,
+    });
+
+    //---------------------------------------------------------------------
+    // 4. Assemble Step Functions workflow
+    //---------------------------------------------------------------------
+    const invokeCollector = new tasks.LambdaInvoke(this, 'InvokeCollector', {
+      lambdaFunction: dataCollector,
+      payloadResponseOnly: true,
+      outputPath: '$',
+    });
+
+    const invokePrep = new tasks.LambdaInvoke(this, 'InvokePrep', {
+      lambdaFunction: dataPrep,
+      payload: sfn.TaskInput.fromObject({ raw_key: sfn.JsonPath.stringAt('$.s3_key') }),
+      payloadResponseOnly: true,
+      outputPath: '$',
+    });
+
+    const definition = invokeCollector.next(invokePrep).next(trainingJobTask);
+
+    const stateMachine = new sfn.StateMachine(this, 'ArchTrainingStateMachine', {
+      definition,
+      timeout: cdk.Duration.hours(3),
+    });
+
+    //---------------------------------------------------------------------
+    // 5. EventBridge schedule
+    //---------------------------------------------------------------------
+    const minutes = props.scheduleMinutes ?? 1440; // default daily
+    new events.Rule(this, 'ArchTrainingSchedule', {
+      schedule: events.Schedule.rate(cdk.Duration.minutes(minutes)),
+      targets: [new targets.SfnStateMachine(stateMachine)],
+    });
+  }
+}

--- a/demo-cdk/package.json
+++ b/demo-cdk/package.json
@@ -7,15 +7,15 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",
-    "cdk": "cdk"
+    "cdk": "cdk",
+    "lint": "tsc --noEmit"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "aws-cdk": "^2.202.0"
   },
   "dependencies": {
-    "@aws-cdk/aws-apigateway": "^1.204.0",
-    "@aws-cdk/aws-lambda": "^1.204.0",
     "aws-cdk-lib": "^2.202.0",
     "constructs": "^10.4.2"
   }

--- a/demo-cdk/package.json
+++ b/demo-cdk/package.json
@@ -12,6 +12,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
+    "@types/aws-lambda": "^8.10.122",
     "typescript": "^5.0.0",
     "aws-cdk": "^2.202.0"
   },

--- a/demo-cdk/training/llm_finetune.py
+++ b/demo-cdk/training/llm_finetune.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python
+"""Fine-tune an open-source LLM on architecture Q&A pairs.
+
+This script is designed to run inside the official HuggingFace SageMaker DLC
+image (PyTorch / Transformers).  It expects the following environment
+variables provided by SageMaker training jobs:
+
+  * SM_CHANNEL_TRAIN – directory with one or more .jsonl files where each
+    line contains {"prompt": ..., "completion": ...}
+  * SM_MODEL_DIR     – where to save the final model/artifacts
+  * SM_NUM_GPUS      – number of available GPUs (string)
+
+The hyper-parameters are passed as command-line args from the SageMaker
+training job definition.  We support the most common ones (epochs, lr, batch)
+with sensible defaults.
+"""
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+import torch
+from datasets import load_dataset, Dataset
+from transformers import AutoTokenizer, AutoModelForCausalLM, TrainingArguments, Trainer
+from peft import LoraConfig, get_peft_model
+
+
+HF_CACHE = os.environ.get("HF_HOME", "/opt/ml/processing/hf-cache")
+
+
+def load_training_data(data_dir: Path) -> Dataset:
+    """Loads jsonl files under *data_dir* into a 🤗 Dataset"""
+    files = list(data_dir.glob("*.jsonl"))
+    if not files:
+        raise FileNotFoundError(f"No .jsonl files found in {data_dir}")
+
+    rows = []
+    for fp in files:
+        with open(fp) as f:
+            for line in f:
+                obj = json.loads(line)
+                prompt = obj.get("prompt")
+                completion = obj.get("completion")
+                if prompt and completion:
+                    rows.append({"text": f"{prompt}\n{completion}"})
+    return Dataset.from_list(rows)
+
+
+def tokenize_dataset(dataset: Dataset, tokenizer, block_size: int = 1024):
+    def _tokenize(example):
+        return tokenizer(example["text"], truncation=True, max_length=block_size)
+
+    return dataset.map(_tokenize, batched=True, remove_columns=["text"])
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model_name_or_path", default="tiiuae/falcon-7b-instruct")
+    parser.add_argument("--num_train_epochs", type=int, default=1)
+    parser.add_argument("--learning_rate", type=float, default=2e-5)
+    parser.add_argument("--per_device_train_batch_size", type=int, default=2)
+    parser.add_argument("--logging_steps", type=int, default=10)
+    parser.add_argument("--max_seq_length", type=int, default=1024)
+    args = parser.parse_args()
+
+    train_dir = Path(os.environ["SM_CHANNEL_TRAIN"])
+    model_dir = Path(os.environ["SM_MODEL_DIR"])
+
+    tokenizer = AutoTokenizer.from_pretrained(args.model_name_or_path, cache_dir=HF_CACHE)
+    tokenizer.pad_token = tokenizer.eos_token
+
+    base_model = AutoModelForCausalLM.from_pretrained(
+        args.model_name_or_path,
+        cache_dir=HF_CACHE,
+        torch_dtype=torch.float16 if torch.cuda.is_available() else torch.float32,
+    )
+
+    # LoRA config (lightweight fine-tune)
+    lora_cfg = LoraConfig(
+        r=8,
+        lora_alpha=32,
+        target_modules=["q_proj", "v_proj"],
+        lora_dropout=0.05,
+        bias="none",
+        task_type="CAUSAL_LM",
+    )
+
+    model = get_peft_model(base_model, lora_cfg)
+
+    raw_ds = load_training_data(train_dir)
+    tokenized_ds = tokenize_dataset(raw_ds, tokenizer, args.max_seq_length)
+
+    training_args = TrainingArguments(
+        output_dir=str(model_dir),
+        per_device_train_batch_size=args.per_device_train_batch_size,
+        learning_rate=args.learning_rate,
+        num_train_epochs=args.num_train_epochs,
+        logging_steps=args.logging_steps,
+        save_total_limit=1,
+        fp16=torch.cuda.is_available(),
+        optim="adamw_torch",
+        report_to=["tensorboard"],
+    )
+
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        train_dataset=tokenized_ds,
+        tokenizer=tokenizer,
+    )
+
+    trainer.train()
+
+    # Save adapter config + base model ref
+    trainer.save_model()
+    tokenizer.save_pretrained(model_dir)
+
+    # Write success marker for SageMaker
+    with open(model_dir / "complete", "w") as f:
+        f.write("success")
+
+
+if __name__ == "__main__":
+    main()

--- a/demo-cdk/training/requirements.txt
+++ b/demo-cdk/training/requirements.txt
@@ -1,0 +1,6 @@
+torch>=2.1
+transformers>=4.39
+datasets>=2.18
+peft>=0.8
+accelerate>=0.27
+scipy

--- a/demo-cdk/tsconfig.json
+++ b/demo-cdk/tsconfig.json
@@ -4,6 +4,8 @@
     "module": "commonjs",
     "lib": ["es2020"],
     "outDir": "dist",
+    "rootDir": "./",
+    "moduleResolution": "node",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,

--- a/internal/llm/arch_client.go
+++ b/internal/llm/arch_client.go
@@ -1,0 +1,45 @@
+THIS SHOULD BE A LINTER ERRORpackage llm
+
+import "fmt"
+
+// NewArchClientFromEnv attempts to construct a specialised architecture model
+// client (usually a SageMaker endpoint fine-tuned on your infra docs) based on
+// three environment variables:
+//   CLOUDAI_ARCH_ENDPOINT   – SageMaker endpoint name
+//   CLOUDAI_ARCH_REGION     – AWS region (default us-east-1)
+//   CLOUDAI_ARCH_MODEL_ID   – Optional metadata only, used for cost calc & logs
+//
+// If CLOUDAI_ARCH_ENDPOINT is not set the function returns (nil, nil) so callers
+// can treat the absence of a specialised model as non-fatal.
+func NewArchClientFromEnv() (*Client, error) {
+    endpoint := getenv("CLOUDAI_ARCH_ENDPOINT", "")
+    if endpoint == "" {
+        return nil, nil
+    }
+
+    region := getenv("CLOUDAI_ARCH_REGION", "us-east-1")
+    modelID := getenv("CLOUDAI_ARCH_MODEL_ID", "arch-bot")
+
+    cfg := &AWSModelConfig{
+        Type:         AWSModelSageMaker,
+        ModelID:      modelID,
+        EndpointName: endpoint,
+        Region:       region,
+        MaxTokens:    2048,
+        Temperature:  0.1,
+    }
+
+    awsClient, err := NewAWSClient(cfg)
+    if err != nil {
+        return nil, fmt.Errorf("failed to create architecture SageMaker client: %w", err)
+    }
+
+    // Use a relaxed daily budget – specialised model, likely infrequent
+    cm := NewCostManager(2.0) // $2/day default
+
+    return &Client{
+        useAWS:      true,
+        awsClient:   awsClient,
+        costManager: cm,
+    }, nil
+}

--- a/internal/llm/arch_client.go
+++ b/internal/llm/arch_client.go
@@ -1,6 +1,9 @@
-THIS SHOULD BE A LINTER ERRORpackage llm
+package llm
 
-import "fmt"
+import (
+    "fmt"
+    "os"
+)
 
 // NewArchClientFromEnv attempts to construct a specialised architecture model
 // client (usually a SageMaker endpoint fine-tuned on your infra docs) based on
@@ -12,13 +15,19 @@ import "fmt"
 // If CLOUDAI_ARCH_ENDPOINT is not set the function returns (nil, nil) so callers
 // can treat the absence of a specialised model as non-fatal.
 func NewArchClientFromEnv() (*Client, error) {
-    endpoint := getenv("CLOUDAI_ARCH_ENDPOINT", "")
+    endpoint := os.Getenv("CLOUDAI_ARCH_ENDPOINT")
     if endpoint == "" {
         return nil, nil
     }
 
-    region := getenv("CLOUDAI_ARCH_REGION", "us-east-1")
-    modelID := getenv("CLOUDAI_ARCH_MODEL_ID", "arch-bot")
+    region := os.Getenv("CLOUDAI_ARCH_REGION")
+    if region == "" {
+        region = "us-east-1"
+    }
+    modelID := os.Getenv("CLOUDAI_ARCH_MODEL_ID")
+    if modelID == "" {
+        modelID = "arch-bot"
+    }
 
     cfg := &AWSModelConfig{
         Type:         AWSModelSageMaker,

--- a/internal/llm/protector.go
+++ b/internal/llm/protector.go
@@ -1,0 +1,111 @@
+package llm
+
+import (
+    "regexp"
+    "strconv"
+    "strings"
+)
+
+// DataProtector redacts sensitive AWS identifiers from prompts before they
+// are sent to external LLM providers and allows them to be restored afterwards.
+//
+// The strategy is simple but effective:
+// 1. Identify well-known sensitive patterns via regular expressions
+//    (ARNs, account IDs, IP addresses, S3 URLs, etc.).
+// 2. Replace each match with a deterministic placeholder such as
+//    [[ARN_1]], [[ACCOUNT_ID_2]], etc.
+// 3. Keep an in-memory map so the original values can be re-hydrated once the
+//    LLM has produced its answer.
+//
+// NOTE: The mapping is intentionally NOT written to disk to avoid persisting
+// sensitive material. Callers that need cross-process re-hydration can marshal
+// the map to an encrypted store (e.g. DynamoDB + KMS) – left to the caller.
+//
+// The protector is *stateless* from the point of view of concurrent requests;
+// create a fresh instance per request or guard access with a mutex if you want
+// to reuse one instance.
+
+type DataProtector struct {
+    // placeholder -> original
+    replacements map[string]string
+    nextIndex    int
+}
+
+func NewDataProtector() *DataProtector {
+    return &DataProtector{
+        replacements: make(map[string]string),
+        nextIndex:    1,
+    }
+}
+
+// Scrub replaces sensitive tokens in the given text with placeholders and
+// returns the scrubbed text. The mapping is stored internally so the caller can
+// later reverse the process via Unscrub.
+func (p *DataProtector) Scrub(text string) string {
+    if text == "" {
+        return text
+    }
+
+    // Ordered list matters – longer / more specific patterns first.
+    patterns := []struct {
+        name string
+        re   *regexp.Regexp
+    }{
+        {"ARN", regexp.MustCompile(`arn:[A-Za-z0-9\-_:/.]+`)},
+        {"ACCOUNT_ID", regexp.MustCompile(`\b\d{12}\b`)},
+        {"IP", regexp.MustCompile(`\b\d{1,3}(?:\.\d{1,3}){3}\b`)},
+        {"S3", regexp.MustCompile(`s3://[A-Za-z0-9.\-_/]+`)},
+    }
+
+    scrubbed := text
+    for _, pat := range patterns {
+        scrubbed = p.replaceAll(scrubbed, pat.re, pat.name)
+    }
+
+    return scrubbed
+}
+
+func (p *DataProtector) replaceAll(input string, re *regexp.Regexp, tag string) string {
+    matches := re.FindAllStringIndex(input, -1)
+    if len(matches) == 0 {
+        return input
+    }
+
+    // Work with a builder to avoid repeated string allocations.
+    var b strings.Builder
+    last := 0
+    for _, loc := range matches {
+        start, end := loc[0], loc[1]
+        sensitive := input[start:end]
+
+        placeholder := p.buildPlaceholder(tag)
+        p.replacements[placeholder] = sensitive
+
+        b.WriteString(input[last:start])
+        b.WriteString(placeholder)
+        last = end
+    }
+    b.WriteString(input[last:])
+    return b.String()
+}
+
+func (p *DataProtector) buildPlaceholder(tag string) string {
+    ph := "[[" + tag + "_" + strconv.Itoa(p.nextIndex) + "]]"
+    p.nextIndex++
+    return ph
+}
+
+// Unscrub reverses placeholders previously inserted by Scrub.
+// If the text does not contain any placeholders known to this protector the
+// original text is returned unchanged.
+func (p *DataProtector) Unscrub(text string) string {
+    if len(p.replacements) == 0 || text == "" {
+        return text
+    }
+
+    result := text
+    for placeholder, original := range p.replacements {
+        result = strings.ReplaceAll(result, placeholder, original)
+    }
+    return result
+}

--- a/internal/llm/router.go
+++ b/internal/llm/router.go
@@ -1,0 +1,74 @@
+package llm
+
+import (
+    "context"
+    "strings"
+)
+
+// Router decides which LLM backend should handle a given question and ensures
+// that sensitive data is redacted before it leaves the local process.
+//
+// The default heuristic is intentionally *very* simple for now – keyword
+// matching – but the public API allows you to swap in a smarter classifier
+// (e.g. embeddings similarity or a fine-tuned classifier) later without
+// changing callers.
+//
+// A Router is cheap to create; instantiate one per CLI invocation.
+
+type Router struct {
+    archClient    *Client // Fine-tuned SageMaker (architecture-aware) model – optional
+    generalClient *Client // General purpose LLM (Bedrock/Ollama/OpenAI)
+
+    protector *DataProtector
+
+    // naive keyword trigger list for the architecture brain
+    archKeywords []string
+}
+
+// NewRouter constructs a router.
+//
+// If archClient is nil the router silently falls back to the generalClient.
+func NewRouter(archClient, generalClient *Client) *Router {
+    kw := []string{"architecture", "lambda", "sns", "s3", "vpc", "subnet", "step function", "eventbridge", "api gateway", "trigger", "cloudformation"}
+    return &Router{
+        archClient:    archClient,
+        generalClient: generalClient,
+        protector:     NewDataProtector(),
+        archKeywords:  kw,
+    }
+}
+
+// Answer selects the backend, scrubs the prompt + context, forwards the request
+// and returns the de-scrubbed answer.
+func (r *Router) Answer(ctx context.Context, question, context string) (string, error) {
+    // 1. Scrub potentially sensitive data.
+    scrubbedQuestion := r.protector.Scrub(question)
+    scrubbedContext := r.protector.Scrub(context)
+
+    // 2. Choose backend.
+    client := r.chooseClient(strings.ToLower(question))
+
+    // 3. Forward.
+    answer, err := client.Answer(ctx, scrubbedQuestion, scrubbedContext)
+    if err != nil {
+        return "", err
+    }
+
+    // 4. De-scrub.
+    return r.protector.Unscrub(answer), nil
+}
+
+func (r *Router) chooseClient(lowerQ string) *Client {
+    if r.archClient == nil {
+        return r.generalClient
+    }
+
+    for _, kw := range r.archKeywords {
+        if strings.Contains(lowerQ, kw) {
+            return r.archClient
+        }
+    }
+
+    // default
+    return r.generalClient
+}


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Introduce multi-model AI routing, data protection, and a SageMaker training pipeline to enable specialized, architecture-aware responses.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This PR establishes the core architecture for a "multi-brain" AI system. It includes a data protection layer to redact sensitive information, a router to intelligently select between a general LLM and a new architecture-specific SageMaker model, and a CDK-deployable pipeline for continuous SageMaker model training on AWS infrastructure metadata.