### PR TITLE
Fix SageMaker training job configuration

### DIFF
--- a/demo-cdk/lib/arch-training-stack.ts
+++ b/demo-cdk/lib/arch-training-stack.ts
@@ -172,7 +172,7 @@ def handler(event, context):
       },
       resourceConfig: {
         instanceCount: 1,
-        instanceType: new ec2.InstanceType('ml.m5.large'),
+        instanceType: new ec2.InstanceType('ml.g4dn.xlarge'),
         volumeSize: cdk.Size.gibibytes(30),
       },
       role: sagemakerExecRole,


### PR DESCRIPTION
Update SageMaker training job instance type to `ml.g4dn.xlarge` to match the GPU-optimized container image.